### PR TITLE
refactor: 统一代码风格为单引号并格式化

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,42 +1,42 @@
-import js from "@eslint/js";
-import ts from "typescript-eslint";
-import prettier from "eslint-config-prettier";
-import prettierPlugin from "eslint-plugin-prettier";
-import { defineConfig } from "eslint/config";
-import compat from "eslint-plugin-compat";
-import globals from "globals";
+import js from '@eslint/js'
+import ts from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+import prettierPlugin from 'eslint-plugin-prettier'
+import { defineConfig } from 'eslint/config'
+import compat from 'eslint-plugin-compat'
+import globals from 'globals'
 
 export default defineConfig(
   {
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.es2020,
+        ...globals.es2020
       },
       parserOptions: {
-        project: "./tsconfig.json",
+        project: './tsconfig.json'
       },
-      sourceType: "module",
-    },
+      sourceType: 'module'
+    }
   },
   js.configs.recommended,
   ...ts.configs.recommended,
   {
     plugins: {
       compat: compat,
-      prettier: prettierPlugin,
+      prettier: prettierPlugin
     },
-    files: ["src/**"],
+    files: ['src/**'],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/ban-ts-comment": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
-      "@typescript-eslint/consistent-type-imports": "error",
-      "@typescript-eslint/no-this-alias": "off",
-      "compat/compat": "error",
-      "prettier/prettier": "error",
-    },
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/no-unused-expressions': 'off',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/no-this-alias': 'off',
+      'compat/compat': 'error',
+      'prettier/prettier': 'error'
+    }
   },
   prettier,
-  { ignores: ["dist/", "node_modules/", "rollup.config.js"] }
-);
+  { ignores: ['dist/', 'node_modules/', 'rollup.config.js'] }
+)

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-import { Qmsg } from "./src/Qmsg";
+import { Qmsg } from './src/Qmsg'
 
-export default Qmsg;
+export default Qmsg

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,35 +1,35 @@
 // 允许使用 node 或 umd 包
-import commonjs from "@rollup/plugin-commonjs";
+import commonjs from '@rollup/plugin-commonjs'
 // 解析导入的依赖模块路径，以便 Rollup 能够正确找到依赖模块。
-import { nodeResolve } from "@rollup/plugin-node-resolve";
+import { nodeResolve } from '@rollup/plugin-node-resolve'
 // 编译 TS 代码
-import typescript from "@rollup/plugin-typescript";
+import typescript from '@rollup/plugin-typescript'
 // 清空 dist
-import cleaner from "rollup-plugin-clear";
-import json from "@rollup/plugin-json";
-import terser from "@rollup/plugin-terser";
+import cleaner from 'rollup-plugin-clear'
+import json from '@rollup/plugin-json'
+import terser from '@rollup/plugin-terser'
 
 // 模块名
-const moduleName = "Qmsg";
-const outDir = "./dist";
+const moduleName = 'Qmsg'
+const outDir = './dist'
 /**
  *
  * @returns {import('rollup').Plugin}
  */
 function fileStringPlugin() {
   return {
-    name: "file-string-plugin",
+    name: 'file-string-plugin',
     transform(code, id) {
-      if (id.endsWith(".css")) {
+      if (id.endsWith('.css')) {
         return {
           code: /*js*/ `
           const css_text = ${JSON.stringify(code)};
           export default css_text;`,
-          map: null,
-        };
+          map: null
+        }
       }
-    },
-  };
+    }
+  }
 }
 
 /**
@@ -38,70 +38,70 @@ function fileStringPlugin() {
 const output = [
   {
     file: `${outDir}/index.esm.js`, // package.json 中 "module": "dist/index.esm.js"
-    format: "esm", // es module 形式的包， 用来import 导入， 可以tree shaking
-    sourcemap: true,
+    format: 'esm', // es module 形式的包， 用来import 导入， 可以tree shaking
+    sourcemap: true
   },
   {
     file: `${outDir}/index.cjs.js`, // package.json 中 "main": "dist/index.cjs.js",
-    format: "cjs", // commonjs 形式的包， require 导入
-    sourcemap: true,
+    format: 'cjs', // commonjs 形式的包， require 导入
+    sourcemap: true
   },
   {
     file: `${outDir}/index.umd.js`,
     name: moduleName, // 模块名
-    format: "umd", // umd 兼容形式的包， 可以直接应用于网页 script
-    sourcemap: true,
+    format: 'umd', // umd 兼容形式的包， 可以直接应用于网页 script
+    sourcemap: true
   },
   {
     file: `${outDir}/index.amd.js`,
-    format: "amd", // amd 兼容形式的包， 适用于浏览器环境中使用 AMD 加载器加载模块
-    sourcemap: true,
+    format: 'amd', // amd 兼容形式的包， 适用于浏览器环境中使用 AMD 加载器加载模块
+    sourcemap: true
   },
   {
     file: `${outDir}/index.iife.js`,
     name: moduleName, // 模块名
-    format: "iife", // iife 兼容形式的包， 将模块包裹在一个立即执行的函数中。适用于直接在浏览器中使用
-    sourcemap: true,
+    format: 'iife', // iife 兼容形式的包， 将模块包裹在一个立即执行的函数中。适用于直接在浏览器中使用
+    sourcemap: true
   },
   {
     file: `${outDir}/index.system.js`,
     name: moduleName, // 模块名
-    format: "system", // system 兼容形式的包， 可以在浏览器和 Node.js 环境下加载
-    sourcemap: true,
-  },
-];
+    format: 'system', // system 兼容形式的包， 可以在浏览器和 Node.js 环境下加载
+    sourcemap: true
+  }
+]
 
 // 添加压缩版本
-output.forEach((outputItem) => {
+output.forEach(outputItem => {
   output.push({
     ...outputItem,
-    file: outputItem.file.trim().replace(/.js$/, ".min.js"),
+    file: outputItem.file.trim().replace(/.js$/, '.min.js'),
     plugins: [
       terser({
         format: {
-          comments: false,
-        },
-      }),
-    ],
-  });
-});
+          comments: false
+        }
+      })
+    ]
+  })
+})
 
 /** @type {import('rollup').RollupOptions} */
 const config = {
   plugins: [
     cleaner({
-      targets: [outDir],
+      targets: [outDir]
     }),
     nodeResolve(),
     commonjs(),
     fileStringPlugin(),
     json({
-      preferConst: true,
+      preferConst: true
     }),
-    typescript(),
+    typescript()
   ],
-  input: "./index.ts", // 源文件入口
-  output: output,
-};
+  input: './index.ts', // 源文件入口
+  output: output
+}
 
-export default config;
+export default config

--- a/src/CompatibleProcessing.ts
+++ b/src/CompatibleProcessing.ts
@@ -4,69 +4,69 @@
 function CompatibleProcessing() {
   /* 处理Object.assign不存在的问题 */
   try {
-    if (typeof Object.assign !== "function") {
+    if (typeof Object.assign !== 'function') {
       Object.assign = function (target: any) {
-        target = Object(target);
+        target = Object(target)
         if (arguments.length > 1) {
           // eslint-disable-next-line prefer-rest-params
-          const sourceList = [...arguments].splice(1, arguments.length - 1);
-          sourceList.forEach((sourceItem) => {
+          const sourceList = [...arguments].splice(1, arguments.length - 1)
+          sourceList.forEach(sourceItem => {
             for (const sourceKey in sourceItem) {
               if (Object.prototype.hasOwnProperty.call(sourceItem, sourceKey)) {
-                target[sourceKey] = sourceItem[sourceKey];
+                target[sourceKey] = sourceItem[sourceKey]
               }
             }
-          });
+          })
         }
-        return target;
-      };
+        return target
+      }
     }
   } catch (error) {
-    console.warn("Qmsg CompatibleProcessing Object.assign error", error);
+    console.warn('Qmsg CompatibleProcessing Object.assign error', error)
   }
 
   /* 'classList' 兼容处理，add，remove不支持传入多个cls参数 */
   try {
-    if (!("classList" in document.documentElement)) {
-      Object.defineProperty(HTMLElement.prototype, "classList", {
+    if (!('classList' in document.documentElement)) {
+      Object.defineProperty(HTMLElement.prototype, 'classList', {
         get: function () {
-          const self = this;
+          const self = this
           function update(fn: any) {
             return function (value: string) {
               const classes = self.className.split(/\s+/g),
-                index = classes.indexOf(value);
-              fn(classes, index, value);
-              self.className = classes.join(" ");
-            };
+                index = classes.indexOf(value)
+              fn(classes, index, value)
+              self.className = classes.join(' ')
+            }
           }
           return {
             add: update(function (classes: string[], index: number, value: string) {
-              if (!~index) classes.push(value);
+              if (!~index) classes.push(value)
             }),
 
             remove: update(function (classes: string[], index: number) {
-              if (~index) classes.splice(index, 1);
+              if (~index) classes.splice(index, 1)
             }),
 
             toggle: update(function (classes: string[], index: number, value: string) {
-              if (~index) classes.splice(index, 1);
-              else classes.push(value);
+              if (~index) classes.splice(index, 1)
+              else classes.push(value)
             }),
 
             contains: function (value: string) {
-              return !!~self.className.split(/\s+/g).indexOf(value);
+              return !!~self.className.split(/\s+/g).indexOf(value)
             },
 
             item: function (index: number) {
-              return self.className.split(/\s+/g)[index] || null;
-            },
-          };
-        },
-      });
+              return self.className.split(/\s+/g)[index] || null
+            }
+          }
+        }
+      })
     }
   } catch (error) {
-    console.warn("Qmsg CompatibleProcessing HTMLElement.prototype.classList warning", error);
+    console.warn('Qmsg CompatibleProcessing HTMLElement.prototype.classList warning', error)
   }
 }
 
-export { CompatibleProcessing };
+export { CompatibleProcessing }

--- a/src/Qmsg.ts
+++ b/src/Qmsg.ts
@@ -1,39 +1,39 @@
-import { CompatibleProcessing } from "./CompatibleProcessing";
-import { QmsgDefaultConfig } from "./QmsgDefaultConfig";
-import { QmsgIcon } from "./QmsgIcon";
-import { QmsgInstStorage } from "./QmsgInstStorage";
-import { QmsgUtils } from "./QmsgUtils";
-import { QmsgInstHandler } from "./QmsgInstHandler";
-import { QmsgEvent } from "./QmsgEvent";
-import type { QmsgMsg } from "./QmsgInst";
-import type { QmsgConfig } from "./QmsgConfig";
-import { version } from "./../package.json";
+import { CompatibleProcessing } from './CompatibleProcessing'
+import { QmsgDefaultConfig } from './QmsgDefaultConfig'
+import { QmsgIcon } from './QmsgIcon'
+import { QmsgInstStorage } from './QmsgInstStorage'
+import { QmsgUtils } from './QmsgUtils'
+import { QmsgInstHandler } from './QmsgInstHandler'
+import { QmsgEvent } from './QmsgEvent'
+import type { QmsgMsg } from './QmsgInst'
+import type { QmsgConfig } from './QmsgConfig'
+import { version } from './../package.json'
 
 /** 实例配置（可选） */
-export type QmsgConfigPartial = Partial<QmsgConfig>;
+export type QmsgConfigPartial = Partial<QmsgConfig>
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-type QmsgConfigContent = string | boolean | number | symbol | Function | bigint | null | undefined;
+type QmsgConfigContent = string | boolean | number | symbol | Function | bigint | null | undefined
 
 /* 执行兼容 */
-CompatibleProcessing();
+CompatibleProcessing()
 
 class Qmsg {
   /** 数据 */
   $data: {
     /** 版本号 */
-    version: string;
+    version: string
     /** 数据 */
-    config: typeof QmsgDefaultConfig;
+    config: typeof QmsgDefaultConfig
     /** 图标svg */
-    icon: typeof QmsgIcon;
+    icon: typeof QmsgIcon
     /** 每个Qmsg实例 */
-    instanceStorage: typeof QmsgInstStorage;
-  };
+    instanceStorage: typeof QmsgInstStorage
+  }
   /**
    * 事件工具类
    */
-  $eventUtils: typeof QmsgEvent;
+  $eventUtils: typeof QmsgEvent
   /**
    * 实例化
    * @param config 配置
@@ -43,130 +43,130 @@ class Qmsg {
       version: version,
       config: QmsgDefaultConfig,
       icon: QmsgIcon,
-      instanceStorage: QmsgInstStorage,
-    };
-    this.$eventUtils = QmsgEvent;
-    this.$eventUtils.visibilitychange.addEvent();
-    this.config(config);
+      instanceStorage: QmsgInstStorage
+    }
+    this.$eventUtils = QmsgEvent
+    this.$eventUtils.visibilitychange.addEvent()
+    this.config(config)
   }
   /**
    * 修改默认配置
    * @param config 配置
    */
   config(config?: QmsgConfigPartial) {
-    if (config == null) return;
-    if (typeof config !== "object") return;
+    if (config == null) return
+    if (typeof config !== 'object') return
     // @ts-ignore
-    QmsgDefaultConfig.INS_DEFAULT = null;
+    QmsgDefaultConfig.INS_DEFAULT = null
     // @ts-ignore
-    QmsgDefaultConfig.INS_DEFAULT = config;
+    QmsgDefaultConfig.INS_DEFAULT = config
   }
   /**
    * 信息Toast
    * @param content 内容
    */
-  info(content: QmsgConfigContent): QmsgMsg;
+  info(content: QmsgConfigContent): QmsgMsg
   /**
    * 信息Toast
    * @param config 配置
    */
-  info(config: QmsgConfigPartial): QmsgMsg;
+  info(config: QmsgConfigPartial): QmsgMsg
   /**
    * 信息Toast
    * @param content 内容
    * @param config 配置
    */
-  info(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg;
+  info(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg
   info(content: any, config?: QmsgConfigPartial): QmsgMsg {
-    const params = QmsgUtils.mergeArgs(content, config);
-    params.type = "info";
-    return QmsgInstHandler.call(this, params);
+    const params = QmsgUtils.mergeArgs(content, config)
+    params.type = 'info'
+    return QmsgInstHandler.call(this, params)
   }
   /**
    * 警告Toast
    * @param content 内容
    */
-  warning(content: QmsgConfigContent): QmsgMsg;
+  warning(content: QmsgConfigContent): QmsgMsg
   /**
    * 警告Toast
    * @param config 配置
    */
-  warning(config: QmsgConfigPartial): QmsgMsg;
+  warning(config: QmsgConfigPartial): QmsgMsg
   /**
    * 警告Toast
    * @param content 内容
    * @param config 配置
    */
-  warning(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg;
+  warning(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg
   warning(content: any, config?: QmsgConfigPartial): QmsgMsg {
-    const params = QmsgUtils.mergeArgs(content, config);
-    params.type = "warning";
-    return QmsgInstHandler.call(this, params);
+    const params = QmsgUtils.mergeArgs(content, config)
+    params.type = 'warning'
+    return QmsgInstHandler.call(this, params)
   }
   /**
    * 成功Toast
    * @param content 内容
    */
-  success(content: QmsgConfigContent): QmsgMsg;
+  success(content: QmsgConfigContent): QmsgMsg
   /**
    * 成功Toast
    * @param config 配置
    */
-  success(config: QmsgConfigPartial): QmsgMsg;
+  success(config: QmsgConfigPartial): QmsgMsg
   /**
    * 成功Toast
    * @param content 内容
    * @param config 配置
    */
-  success(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg;
+  success(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg
   success(content: any, config?: QmsgConfigPartial) {
-    const params = QmsgUtils.mergeArgs(content, config);
-    params.type = "success";
-    return QmsgInstHandler.call(this, params);
+    const params = QmsgUtils.mergeArgs(content, config)
+    params.type = 'success'
+    return QmsgInstHandler.call(this, params)
   }
   /**
    * 失败Toast
    * @param content 内容
    */
-  error(content: QmsgConfigContent): QmsgMsg;
+  error(content: QmsgConfigContent): QmsgMsg
   /**
    * 失败Toast
    * @param config 配置
    */
-  error(config: QmsgConfigPartial): QmsgMsg;
+  error(config: QmsgConfigPartial): QmsgMsg
   /**
    * 失败Toast
    * @param content 内容
    * @param config 配置
    */
-  error(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg;
+  error(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg
   error(content: any, config?: QmsgConfigPartial) {
-    const params = QmsgUtils.mergeArgs(content, config);
-    params.type = "error";
-    return QmsgInstHandler.call(this, params);
+    const params = QmsgUtils.mergeArgs(content, config)
+    params.type = 'error'
+    return QmsgInstHandler.call(this, params)
   }
   /**
    * 加载中Toast
    * @param content 内容
    */
-  loading(content: QmsgConfigContent): QmsgMsg;
+  loading(content: QmsgConfigContent): QmsgMsg
   /**
    * 加载中Toast
    * @param config 配置
    */
-  loading(config: QmsgConfigPartial): QmsgMsg;
+  loading(config: QmsgConfigPartial): QmsgMsg
   /**
    * 加载中Toast
    * @param content 内容
    * @param config 配置
    * @returns
    */
-  loading(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg;
+  loading(content: QmsgConfigContent, config: QmsgConfigPartial): QmsgMsg
   loading(content: any, config?: QmsgConfigPartial): QmsgMsg {
-    const params = QmsgUtils.mergeArgs(content, config);
-    params.type = "loading";
-    params.autoClose = false;
-    return QmsgInstHandler.call(this, params);
+    const params = QmsgUtils.mergeArgs(content, config)
+    params.type = 'loading'
+    params.autoClose = false
+    return QmsgInstHandler.call(this, params)
   }
   /**
    * 根据uuid删除Qmsg实例和元素
@@ -174,19 +174,19 @@ class Qmsg {
    */
 
   remove(uuid: string) {
-    QmsgInstStorage.remove(uuid);
+    QmsgInstStorage.remove(uuid)
   }
   /**
    * 关闭当前Qmsg创建的所有的实例
    */
   closeAll() {
     for (let index = QmsgInstStorage.insInfoList.length - 1; index >= 0; index--) {
-      const item = QmsgInstStorage.insInfoList[index];
-      item && item.instance && item.instance.close();
+      const item = QmsgInstStorage.insInfoList[index]
+      item && item.instance && item.instance.close()
     }
   }
 }
 
-const qmsg = new Qmsg();
+const qmsg = new Qmsg()
 
-export { qmsg as Qmsg };
+export { qmsg as Qmsg }

--- a/src/QmsgAnimation.ts
+++ b/src/QmsgAnimation.ts
@@ -1,22 +1,22 @@
 export type QmsgAnimationState = {
   /** 显示中 */
-  opening: string;
+  opening: string
   /** 显示完成 */
-  done: string;
+  done: string
   /** 关闭中 */
-  closing: string;
-};
+  closing: string
+}
 
 export const QmsgAnimation = {
   /** 状态 & 动画 */
   $state: <QmsgAnimationState>{
-    opening: "MessageMoveIn",
-    done: "",
-    closing: "MessageMoveOut",
+    opening: 'MessageMoveIn',
+    done: '',
+    closing: 'MessageMoveOut'
   },
   $name: {
-    startNameList: ["animationName", "WebkitAnimationName", "MozAnimationName", "msAnimationName", "OAnimationName"],
-    endNameList: ["animationend", "webkitAnimationEnd", "mozAnimationEnd", "MSAnimationEnd", "oanimationend"],
+    startNameList: ['animationName', 'WebkitAnimationName', 'MozAnimationName', 'msAnimationName', 'OAnimationName'],
+    endNameList: ['animationend', 'webkitAnimationEnd', 'mozAnimationEnd', 'MSAnimationEnd', 'oanimationend']
   },
   /**
    * 是否支持动画属性
@@ -28,8 +28,8 @@ export const QmsgAnimation = {
    */
   get CAN_ANIMATION() {
     this.__CAN_ANIMATION__ =
-      this.__CAN_ANIMATION__ ?? this.getStyleAnimationNameValue(document.createElement("div")) != null;
-    return this.__CAN_ANIMATION__;
+      this.__CAN_ANIMATION__ ?? this.getStyleAnimationNameValue(document.createElement('div')) != null
+    return this.__CAN_ANIMATION__
   },
   /**
    * 获取元素上的animationName属性
@@ -37,10 +37,10 @@ export const QmsgAnimation = {
    */
   getStyleAnimationNameValue(element: HTMLElement) {
     for (let index = 0; index < this.$name.startNameList.length; index++) {
-      const animationName = this.$name.startNameList[index];
-      const animationNameValue = (element.style as any)[animationName];
+      const animationName = this.$name.startNameList[index]
+      const animationNameValue = (element.style as any)[animationName]
       if (animationNameValue != null) {
-        return animationNameValue;
+        return animationNameValue
       }
     }
   },
@@ -49,11 +49,11 @@ export const QmsgAnimation = {
    * @param element
    * @param animationNameValue
    */
-  setStyleAnimationName(element: HTMLElement, animationNameValue: QmsgAnimationState[keyof QmsgAnimationState] = "") {
-    this.$name.startNameList.forEach((animationName) => {
+  setStyleAnimationName(element: HTMLElement, animationNameValue: QmsgAnimationState[keyof QmsgAnimationState] = '') {
+    this.$name.startNameList.forEach(animationName => {
       if (animationName in element.style) {
-        (element.style as any)[animationName] = animationNameValue;
+        ;(element.style as any)[animationName] = animationNameValue
       }
-    });
-  },
-};
+    })
+  }
+}

--- a/src/QmsgCSS.ts
+++ b/src/QmsgCSS.ts
@@ -1,7 +1,7 @@
-import { QmsgDefaultConfig } from "./QmsgDefaultConfig";
-import { QmsgUtils } from "./QmsgUtils";
-import indexCSS from "./css/index.css";
-import keyframesCSS from "./css/keyframes.css";
+import { QmsgDefaultConfig } from './QmsgDefaultConfig'
+import { QmsgUtils } from './QmsgUtils'
+import indexCSS from './css/index.css'
+import keyframesCSS from './css/keyframes.css'
 
 export const QmsgCSS = {
   css: `
@@ -13,10 +13,10 @@ export const QmsgCSS = {
    * 获取CSS元素
    */
   getStyleElement() {
-    const $style = document.createElement("style");
-    $style.setAttribute("type", "text/css");
-    $style.setAttribute("data-type", QmsgDefaultConfig.PLUGIN_NAME);
-    QmsgUtils.setSafeHTML($style, QmsgCSS.css);
-    return $style;
-  },
-};
+    const $style = document.createElement('style')
+    $style.setAttribute('type', 'text/css')
+    $style.setAttribute('data-type', QmsgDefaultConfig.PLUGIN_NAME)
+    QmsgUtils.setSafeHTML($style, QmsgCSS.css)
+    return $style
+  }
+}

--- a/src/QmsgConfig.ts
+++ b/src/QmsgConfig.ts
@@ -1,22 +1,22 @@
-import type { QmsgMsg } from "./QmsgInst";
+import type { QmsgMsg } from './QmsgInst'
 
 /** 实例所在的位置 */
 export type QmsgPosition =
-  | "topleft"
-  | "top"
-  | "topright"
-  | "left"
-  | "center"
-  | "right"
-  | "bottomleft"
-  | "bottom"
-  | "bottomright";
+  | 'topleft'
+  | 'top'
+  | 'topright'
+  | 'left'
+  | 'center'
+  | 'right'
+  | 'bottomleft'
+  | 'bottom'
+  | 'bottomright'
 
 /** 实例类型 */
-export type QmsgType = "info" | "warning" | "success" | "error" | "loading";
+export type QmsgType = 'info' | 'warning' | 'success' | 'error' | 'loading'
 
 /** 实例内容超出宽度时的处理方式 */
-export type QmsgLimitWidthWrap = "no-wrap" | "wrap" | "ellipsis";
+export type QmsgLimitWidthWrap = 'no-wrap' | 'wrap' | 'ellipsis'
 
 /** 实例配置 */
 export interface QmsgConfig {
@@ -24,133 +24,133 @@ export interface QmsgConfig {
    * 实例插入到页面的父元素
    * @default document.body || document.documentElement
    */
-  parent?: HTMLElement | Document | DocumentFragment | Node | Element;
+  parent?: HTMLElement | Document | DocumentFragment | Node | Element
   /**
    * 是否使用shadowRoot（在其内部插入实例元素）
    * @default true
    */
-  useShadowRoot?: boolean;
+  useShadowRoot?: boolean
   /**
    * shadowRoot模式
    * @default "open"
    */
-  shadowRootMode?: ShadowRootMode;
+  shadowRootMode?: ShadowRootMode
   /**
    * 是否使用动画
    * @default true
    */
-  animation?: boolean;
+  animation?: boolean
   /**
    * 是否自动关闭
    *
    * 注意：在`type`为`loading`时，强制该值为`false`
    * @default true
    */
-  autoClose?: boolean;
+  autoClose?: boolean
   /**
    * 通过监听事件来判断是否(鼠标悬停|触摸进入)时暂停自动关闭，当(鼠标离开|触摸离开)时会自动重启自动关闭定时器
    * @default true
    */
-  listenEventToPauseAutoClose?: boolean;
+  listenEventToPauseAutoClose?: boolean
   /**
    * 通过监听`visibilitychange`事件在来回切换标签页时自动关闭实例
    *
    * 前置条件：`autoClose`: true，`timeout`: >0
    * @default true
    */
-  listenEventToCloseInstance?: boolean;
+  listenEventToCloseInstance?: boolean
   /**
    * 显示的内容
    * @default ""
    */
-  content?: string;
+  content?: string
   /**
    * 显示的内容是否是html，否则是普通的text
    * @default false
    */
-  isHTML?: boolean;
+  isHTML?: boolean
   /**
    * 弹出的位置
    * @default "center"
    */
-  position?: QmsgPosition;
+  position?: QmsgPosition
   /**
    * 是否在最右边显示关闭图标
    * @default false
    */
-  showClose?: boolean;
+  showClose?: boolean
   /**
    * Qmsg最大显示的数量，超出最大数量时，会自动关闭最旧的实例
    * @default 5
    */
-  maxNums?: number;
+  maxNums?: number
   /**
    * 关闭Qmsg时触发的回调函数
    * @default null
    */
-  onClose?: (<T extends QmsgMsg>(this: T) => void) | null;
+  onClose?: (<T extends QmsgMsg>(this: T) => void) | null
   /**
    * 是否显示左边的icon图标
    * @default true
    */
-  showIcon?: boolean;
+  showIcon?: boolean
   /**
    * 是否使内容进行换行显示
    * @default false
    */
-  showMoreContent?: boolean;
+  showMoreContent?: boolean
   /**
    * 弹出顺序是否逆反
    * + `true`：按顺序追加弹出
    * + `false`：逆序追加弹出
    * @default false
    */
-  showReverse?: boolean;
+  showReverse?: boolean
   /**
    * 最大显示的时长(ms)
    * @default 2500
    */
-  timeout?: number;
+  timeout?: number
   /**
    * 弹出类型
    *
    * 信息、警告、成功、错误、加载中
    */
-  type: QmsgType;
+  type: QmsgType
   /**
    * 元素层级
    * @default 50000
    */
-  zIndex?: number | (() => number);
+  zIndex?: number | (() => number)
   /**
    * 自定义的样式
    * @default ""
    */
-  style?: string;
+  style?: string
   /**
    * 自定义类名
    * @default ""
    */
-  customClass?: string;
+  customClass?: string
   /**
    * 是否限制宽度，当该值为`true`时，会限制宽度，超出限制宽度时，会进行换行或显示为省略号
    *
    * 前置条件：`limitWidthNum`: >0
    * @default false
    */
-  isLimitWidth?: boolean;
+  isLimitWidth?: boolean
   /**
    * 限制宽度的数值
    *
    * 前置条件：`isLimitWidth`: true
    * @default 200
    */
-  limitWidthNum?: number | string;
+  limitWidthNum?: number | string
   /**
    * 当超出限制宽度时，是否换行还是显示为省略号
    * @default "wrap"
    */
-  limitWidthWrap?: "no-wrap" | "wrap" | "ellipsis";
+  limitWidthWrap?: 'no-wrap' | 'wrap' | 'ellipsis'
   /**
    * 是否在控制台打印content信息
    *
@@ -164,7 +164,7 @@ export interface QmsgConfig {
          * 配置项
          */
         qmsgInst: typeof QmsgMsg.prototype
-      ) => boolean);
+      ) => boolean)
   /**
    * 在实例初始化完毕（元素创建完成且添加到`parent`内）后自动调用该函数
    * @default null
@@ -177,5 +177,5 @@ export interface QmsgConfig {
         qmsgInst: typeof QmsgMsg.prototype
       ) => void)
     | null
-    | undefined;
+    | undefined
 }

--- a/src/QmsgDefaultConfig.ts
+++ b/src/QmsgDefaultConfig.ts
@@ -1,13 +1,13 @@
-import type { QmsgConfig } from "./QmsgConfig";
+import type { QmsgConfig } from './QmsgConfig'
 
 export const QmsgDefaultConfig = {
   /** 声明插件名称 */
   get PLUGIN_NAME() {
-    return "qmsg";
+    return 'qmsg'
   },
   /** 命名空间，用于css和事件 */
   get NAMESPACE() {
-    return "qmsg";
+    return 'qmsg'
   },
   /** 实例配置的固定的默认值，在初始化时会插入值 */
   INS_DEFAULT: {} as QmsgConfig,
@@ -16,14 +16,14 @@ export const QmsgDefaultConfig = {
     return {
       parent: document.body || document.documentElement,
       useShadowRoot: true,
-      shadowRootMode: "open",
+      shadowRootMode: 'open',
       animation: true,
       autoClose: true,
       listenEventToPauseAutoClose: true,
       listenEventToCloseInstance: true,
-      content: "",
+      content: '',
       isHTML: false,
-      position: "top",
+      position: 'top',
       showClose: false,
       maxNums: 5,
       onClose: null,
@@ -31,15 +31,15 @@ export const QmsgDefaultConfig = {
       showMoreContent: false,
       showReverse: false,
       timeout: 2500,
-      type: "info",
+      type: 'info',
       zIndex: 50000,
-      style: "",
-      customClass: "",
+      style: '',
+      customClass: '',
       isLimitWidth: false,
       limitWidthNum: 200,
-      limitWidthWrap: "no-wrap",
+      limitWidthWrap: 'no-wrap',
       consoleLogContent: false,
-      afterRender: null,
-    };
-  },
-};
+      afterRender: null
+    }
+  }
+}

--- a/src/QmsgEvent.ts
+++ b/src/QmsgEvent.ts
@@ -1,4 +1,4 @@
-import { QmsgInstStorage } from "./QmsgInstStorage";
+import { QmsgInstStorage } from './QmsgInstStorage'
 
 export const QmsgEvent = {
   visibilitychange: {
@@ -10,26 +10,26 @@ export const QmsgEvent = {
        * 如果设置了动画，使用close，否则使用destroy
        */
       callback() {
-        if (document.visibilityState === "visible") {
+        if (document.visibilityState === 'visible') {
           // 回到页面
           for (let index = 0; index < QmsgInstStorage.insInfoList.length; index++) {
-            const qmsgStorageItem = QmsgInstStorage.insInfoList[index];
-            const qmsgInst = qmsgStorageItem.instance;
-            const qmsgSetting = qmsgInst.getSetting();
-            const now = Date.now();
+            const qmsgStorageItem = QmsgInstStorage.insInfoList[index]
+            const qmsgInst = qmsgStorageItem.instance
+            const qmsgSetting = qmsgInst.getSetting()
+            const now = Date.now()
             if (
               // loading类型不被自动关闭
-              qmsgSetting.type !== "loading" &&
+              qmsgSetting.type !== 'loading' &&
               // 必须为自动关闭
               qmsgSetting.autoClose &&
               // 存在启动时间，不存在结束时间（未关闭）
-              typeof qmsgInst.endTime !== "number" &&
-              typeof qmsgInst.startTime === "number" &&
-              typeof qmsgSetting.timeout === "number" &&
+              typeof qmsgInst.endTime !== 'number' &&
+              typeof qmsgInst.startTime === 'number' &&
+              typeof qmsgSetting.timeout === 'number' &&
               now - qmsgInst.startTime >= qmsgSetting.timeout
             ) {
               // 超出时间，关闭
-              qmsgInst.close();
+              qmsgInst.close()
             }
           }
         } else {
@@ -37,21 +37,21 @@ export const QmsgEvent = {
         }
       },
       option: {
-        capture: true,
-      } as AddEventListenerOptions,
+        capture: true
+      } as AddEventListenerOptions
     },
     /**
      * 监听事件
      */
     addEvent() {
-      if ("visibilityState" in document) {
+      if ('visibilityState' in document) {
         document.addEventListener(
-          "visibilitychange",
+          'visibilitychange',
           QmsgEvent.visibilitychange.eventConfig.callback,
           QmsgEvent.visibilitychange.eventConfig.option
-        );
+        )
       } else {
-        console.error("Qmsg addEvent visibilityState not support");
+        console.error('Qmsg addEvent visibilityState not support')
       }
     },
     /**
@@ -59,10 +59,10 @@ export const QmsgEvent = {
      */
     removeEvent() {
       document.removeEventListener(
-        "visibilitychange",
+        'visibilitychange',
         QmsgEvent.visibilitychange.eventConfig.callback,
         QmsgEvent.visibilitychange.eventConfig.option
-      );
-    },
-  },
-};
+      )
+    }
+  }
+}

--- a/src/QmsgIcon.ts
+++ b/src/QmsgIcon.ts
@@ -1,11 +1,11 @@
-import type { QmsgType } from "./QmsgConfig";
+import type { QmsgType } from './QmsgConfig'
 
 export const QmsgHeaderCloseIcon = /*css*/ `
 	<svg width="16" height="16" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<rect width="48" height="48" fill="white" fill-opacity="0.01"/>
 		<path d="M14 14L34 34" stroke="#909399" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 		<path d="M14 34L34 14" stroke="#909399" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-	</svg>`;
+	</svg>`
 
 export const QmsgIcon = <Record<QmsgType, string>>{
   info: /*css*/ `
@@ -32,5 +32,5 @@ export const QmsgIcon = <Record<QmsgType, string>>{
 			<path fill="#fff" fill-opacity=".01" d="M0 0h48v48H0z"/>
 			<path d="M4 24c0 11.046 8.954 20 20 20s20-8.954 20-20S35.046 4 24 4" stroke="#409eff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
 			<path d="M36 24c0-6.627-5.373-12-12-12s-12 5.373-12 12 5.373 12 12 12" stroke="#409eff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-		</svg>`,
-};
+		</svg>`
+}

--- a/src/QmsgInst.ts
+++ b/src/QmsgInst.ts
@@ -1,10 +1,10 @@
-import { QmsgAnimation, type QmsgAnimationState } from "./QmsgAnimation";
-import { QmsgCSS } from "./QmsgCSS";
-import { QmsgDefaultConfig } from "./QmsgDefaultConfig";
-import { QmsgIcon, QmsgHeaderCloseIcon } from "./QmsgIcon";
-import { QmsgInstStorage } from "./QmsgInstStorage";
-import type { QmsgConfig } from "./QmsgConfig";
-import { QmsgUtils } from "./QmsgUtils";
+import { QmsgAnimation, type QmsgAnimationState } from './QmsgAnimation'
+import { QmsgCSS } from './QmsgCSS'
+import { QmsgDefaultConfig } from './QmsgDefaultConfig'
+import { QmsgIcon, QmsgHeaderCloseIcon } from './QmsgIcon'
+import { QmsgInstStorage } from './QmsgInstStorage'
+import type { QmsgConfig } from './QmsgConfig'
+import { QmsgUtils } from './QmsgUtils'
 /**
  * 每条消息的构造函数
  */
@@ -12,156 +12,156 @@ export class QmsgMsg {
   /**
    * setTimeout的id
    */
-  timeId: number | undefined = void 0;
+  timeId: number | undefined = void 0
   /**
    * 启动时间
    */
-  startTime: number | null;
+  startTime: number | null
   /**
    * 关闭时间
    */
-  endTime: number | null;
+  endTime: number | null
   /**
    * Qmsg的配置
    */
-  setting: Required<QmsgConfig>;
+  setting: Required<QmsgConfig>
   /**
    * uuid
    */
-  uuid: string;
+  uuid: string
   /**
    * 当前动画状态
    */
-  state: keyof QmsgAnimationState;
+  state: keyof QmsgAnimationState
   /**
    * 当前相同消息的数量
    */
-  repeatNum: number;
+  repeatNum: number
   /**
    * 主元素
    */
-  $Qmsg: HTMLElement;
+  $Qmsg: HTMLElement
   constructor(config: QmsgConfig, uuid: string) {
-    this.timeId = void 0;
-    this.startTime = Date.now();
-    this.endTime = null;
+    this.timeId = void 0
+    this.startTime = Date.now()
+    this.endTime = null
     // this.#setting = Object.assign({}, QmsgStore.DEFAULT, this.option);
-    this.setting = QmsgUtils.toDynamicObject(QmsgDefaultConfig.config, config, QmsgDefaultConfig.INS_DEFAULT);
-    this.uuid = uuid;
-    this.state = "opening";
-    this.$Qmsg = document.createElement("div");
-    this.repeatNum = 1;
+    this.setting = QmsgUtils.toDynamicObject(QmsgDefaultConfig.config, config, QmsgDefaultConfig.INS_DEFAULT)
+    this.uuid = uuid
+    this.state = 'opening'
+    this.$Qmsg = document.createElement('div')
+    this.repeatNum = 1
 
-    this.detectionType();
-    this.init();
+    this.detectionType()
+    this.init()
 
     const consoleLogContent =
-      typeof this.setting.consoleLogContent === "function"
+      typeof this.setting.consoleLogContent === 'function'
         ? this.setting.consoleLogContent(this)
-        : this.setting.consoleLogContent;
+        : this.setting.consoleLogContent
     if (consoleLogContent) {
       // 控制台输出content
-      console.log(this.setting.content);
+      console.log(this.setting.content)
     }
 
-    if (typeof this.setting.afterRender === "function") {
-      this.setting.afterRender(this);
+    if (typeof this.setting.afterRender === 'function') {
+      this.setting.afterRender(this)
     }
   }
   /**
    * 获取当前配置
    */
   getSetting() {
-    return this.setting;
+    return this.setting
   }
   /**
    * 获取当前相同的数量
    */
   getRepeatNum() {
-    return this.repeatNum;
+    return this.repeatNum
   }
   /**
    * 设置repeatNum值
    * @param num 重复的数量
    */
   setRepeatNum(num: number) {
-    this.repeatNum = num;
+    this.repeatNum = num
   }
   /**
    * 设置repeatNum自增
    */
   setRepeatNumIncreasing() {
-    this.repeatNum++;
+    this.repeatNum++
   }
   /**
    * 初始化元素
    */
   private init() {
-    const QmsgContext = this;
-    if (this.setting.customClass && typeof this.setting.customClass === "string") {
+    const QmsgContext = this
+    if (this.setting.customClass && typeof this.setting.customClass === 'string') {
       /* 设置自定义类名 */
-      this.$Qmsg.classList.add(this.setting.customClass);
+      this.$Qmsg.classList.add(this.setting.customClass)
     }
     // 设置svg图标
-    const $svg = QmsgIcon[this.setting.type || "info"];
-    let contentClassName = QmsgUtils.getNameSpacify("content-" + this.setting.type || "info");
+    const $svg = QmsgIcon[this.setting.type || 'info']
+    let contentClassName = QmsgUtils.getNameSpacify('content-' + this.setting.type || 'info')
     if (this.setting.showClose) {
       // 显示 关闭图标
-      contentClassName += " " + QmsgUtils.getNameSpacify("content-with-close");
+      contentClassName += ' ' + QmsgUtils.getNameSpacify('content-with-close')
     }
     // 内容兼容处理
-    const content = this.setting.content || "";
+    const content = this.setting.content || ''
     // 关闭图标 自定义额外className
-    let extraCloseIconClassName = "";
+    let extraCloseIconClassName = ''
     // 关闭图标svg
-    const $closeSvg = QmsgHeaderCloseIcon;
+    const $closeSvg = QmsgHeaderCloseIcon
     if (this.setting.showMoreContent) {
       // 显示更多内容
-      contentClassName += "qmsg-show-more-content";
-      extraCloseIconClassName += "qmsg-show-more-content";
+      contentClassName += 'qmsg-show-more-content'
+      extraCloseIconClassName += 'qmsg-show-more-content'
     }
-    let $closeIcon = "";
+    let $closeIcon = ''
     if (this.setting.showClose) {
       /* 显示右上角的关闭图标按钮 */
-      $closeIcon = /*html*/ `<i class="qmsg-icon qmsg-icon-close ${extraCloseIconClassName}">${$closeSvg}</i>`;
+      $closeIcon = /*html*/ `<i class="qmsg-icon qmsg-icon-close ${extraCloseIconClassName}">${$closeSvg}</i>`
     }
     /* 内容 */
-    const $content = document.createElement("span");
-    const $positionClassName = QmsgUtils.getNameSpacify("data-position", this.setting.position.toLowerCase());
-    const isHTML = this.setting.isHTML;
+    const $content = document.createElement('span')
+    const $positionClassName = QmsgUtils.getNameSpacify('data-position', this.setting.position.toLowerCase())
+    const isHTML = this.setting.isHTML
     if (isHTML) {
       /* 内容是html */
-      QmsgUtils.setSafeHTML($content, content);
+      QmsgUtils.setSafeHTML($content, content)
     } else {
       /* 内容是纯文本 */
-      $content.innerText = content;
+      $content.innerText = content
     }
     if (this.setting.isLimitWidth) {
       /* 限制宽度 */
-      let limitWidthNum = this.setting.limitWidthNum;
-      if (typeof limitWidthNum === "string") {
+      let limitWidthNum = this.setting.limitWidthNum
+      if (typeof limitWidthNum === 'string') {
         if (QmsgUtils.isNumber(limitWidthNum)) {
-          limitWidthNum = limitWidthNum + "px";
+          limitWidthNum = limitWidthNum + 'px'
         }
       } else {
-        limitWidthNum = limitWidthNum.toString() + "px";
+        limitWidthNum = limitWidthNum.toString() + 'px'
       }
-      $content.style.maxWidth = limitWidthNum;
-      $content.style.width = limitWidthNum;
+      $content.style.maxWidth = limitWidthNum
+      $content.style.width = limitWidthNum
 
       /* 设置换行 */
-      if (this.setting.limitWidthWrap === "no-wrap") {
+      if (this.setting.limitWidthWrap === 'no-wrap') {
         /* 禁止换行 */
-        $content.style.whiteSpace = "nowrap";
-      } else if (this.setting.limitWidthWrap === "ellipsis") {
+        $content.style.whiteSpace = 'nowrap'
+      } else if (this.setting.limitWidthWrap === 'ellipsis') {
         /* 禁止换行且显示省略号 */
-        $content.style.whiteSpace = "nowrap";
-        $content.style.overflow = "hidden";
-        $content.style.textOverflow = "ellipsis";
-      } else if (this.setting.limitWidthWrap === "wrap") {
+        $content.style.whiteSpace = 'nowrap'
+        $content.style.overflow = 'hidden'
+        $content.style.textOverflow = 'ellipsis'
+      } else if (this.setting.limitWidthWrap === 'wrap') {
         /* 允许换行 */
         /* 默认的 */
-        $content.style.whiteSpace = "";
+        $content.style.whiteSpace = ''
       }
     }
     QmsgUtils.setSafeHTML(
@@ -169,110 +169,110 @@ export class QmsgMsg {
       /*html*/ `
 			<div class="qmsg-content">
 				<div class="${contentClassName}">
-				${this.setting.showIcon ? `<i class="qmsg-icon">${$svg}</i>` : ""}
+				${this.setting.showIcon ? `<i class="qmsg-icon">${$svg}</i>` : ''}
 					${$content.outerHTML}
 					${$closeIcon}
 				</div>
 			</div>
 			`
-    );
+    )
     /** 内容容器 */
-    const $contentContainer = this.$Qmsg.querySelector<HTMLElement>(".qmsg-content")!;
+    const $contentContainer = this.$Qmsg.querySelector<HTMLElement>('.qmsg-content')!
 
-    this.$Qmsg.classList.add(QmsgUtils.getNameSpacify("item"));
-    this.$Qmsg.setAttribute(QmsgUtils.getNameSpacify("uuid"), this.uuid);
+    this.$Qmsg.classList.add(QmsgUtils.getNameSpacify('item'))
+    this.$Qmsg.setAttribute(QmsgUtils.getNameSpacify('uuid'), this.uuid)
     /** 总根元素 */
-    let $shadowContainer: HTMLElement | null;
+    let $shadowContainer: HTMLElement | null
     /** 根元素 */
-    let $shadowRoot: ShadowRoot | null | undefined | HTMLElement;
+    let $shadowRoot: ShadowRoot | null | undefined | HTMLElement
     /** 容器包裹的元素 */
-    let $wrapper: HTMLElement | null;
-    $shadowContainer = document.querySelector<HTMLElement>(".qmsg-shadow-container");
-    $shadowRoot = this.setting.useShadowRoot ? $shadowContainer?.shadowRoot : $shadowContainer;
+    let $wrapper: HTMLElement | null
+    $shadowContainer = document.querySelector<HTMLElement>('.qmsg-shadow-container')
+    $shadowRoot = this.setting.useShadowRoot ? $shadowContainer?.shadowRoot : $shadowContainer
     if (!$shadowContainer) {
       // 页面中不存在ShadowRoot容器元素
       // 添加新增的ShadowRoot容器元素
-      $shadowContainer = document.createElement("div");
-      $shadowContainer.className = "qmsg-shadow-container";
+      $shadowContainer = document.createElement('div')
+      $shadowContainer.className = 'qmsg-shadow-container'
       if (this.setting.useShadowRoot) {
         $shadowRoot = $shadowContainer.attachShadow({
-          mode: this.setting.shadowRootMode,
-        });
+          mode: this.setting.shadowRootMode
+        })
       } else {
-        $shadowRoot = $shadowContainer;
+        $shadowRoot = $shadowContainer
       }
-      $shadowRoot.appendChild(QmsgCSS.getStyleElement());
+      $shadowRoot.appendChild(QmsgCSS.getStyleElement())
       if (this.setting.style != null) {
         // 插入自定义的style
         // 这里需要插入到每一条的Qmsg内，以便移除实例时把style也移除
-        const __$ownStyle__ = document.createElement("style");
-        __$ownStyle__.setAttribute("type", "text/css");
-        __$ownStyle__.setAttribute("data-id", this.uuid);
-        QmsgUtils.setSafeHTML(__$ownStyle__, this.setting.style);
-        $contentContainer.insertAdjacentElement("afterend", __$ownStyle__);
+        const __$ownStyle__ = document.createElement('style')
+        __$ownStyle__.setAttribute('type', 'text/css')
+        __$ownStyle__.setAttribute('data-id', this.uuid)
+        QmsgUtils.setSafeHTML(__$ownStyle__, this.setting.style)
+        $contentContainer.insertAdjacentElement('afterend', __$ownStyle__)
       }
 
-      this.setting.parent.appendChild($shadowContainer);
+      this.setting.parent.appendChild($shadowContainer)
     }
     if ($shadowRoot == null) {
-      throw new Error("QmsgInst " + QmsgDefaultConfig.PLUGIN_NAME + " $shadowRoot is null");
+      throw new Error('QmsgInst ' + QmsgDefaultConfig.PLUGIN_NAME + ' $shadowRoot is null')
     }
-    $wrapper = $shadowRoot.querySelector<HTMLElement>(`.${QmsgDefaultConfig.NAMESPACE}.${$positionClassName}`);
+    $wrapper = $shadowRoot.querySelector<HTMLElement>(`.${QmsgDefaultConfig.NAMESPACE}.${$positionClassName}`)
     if (!$wrapper) {
-      $wrapper = document.createElement("div");
+      $wrapper = document.createElement('div')
       $wrapper.classList.add(
         QmsgDefaultConfig.NAMESPACE,
-        QmsgUtils.getNameSpacify("wrapper"),
-        QmsgUtils.getNameSpacify("is-initialized"),
+        QmsgUtils.getNameSpacify('wrapper'),
+        QmsgUtils.getNameSpacify('is-initialized'),
         $positionClassName
-      );
-      $shadowRoot.appendChild($wrapper);
+      )
+      $shadowRoot.appendChild($wrapper)
     }
     if (this.setting.showReverse) {
-      $wrapper.style.flexDirection = "column-reverse";
+      $wrapper.style.flexDirection = 'column-reverse'
     } else {
-      $wrapper.style.flexDirection = "column";
+      $wrapper.style.flexDirection = 'column'
     }
-    let zIndex = this.setting.zIndex;
-    if (typeof zIndex === "function") {
-      zIndex = zIndex();
+    let zIndex = this.setting.zIndex
+    if (typeof zIndex === 'function') {
+      zIndex = zIndex()
     }
     if (!isNaN(zIndex)) {
-      $wrapper.style.zIndex = zIndex.toString();
+      $wrapper.style.zIndex = zIndex.toString()
     }
-    $wrapper.appendChild(this.$Qmsg);
-    this.setState(this.$Qmsg, "opening");
+    $wrapper.appendChild(this.$Qmsg)
+    this.setState(this.$Qmsg, 'opening')
     if (this.setting.showClose) {
       /* 关闭按钮绑定点击事件 */
-      const $closeIcon = this.$Qmsg.querySelector<HTMLElement>(".qmsg-icon-close");
+      const $closeIcon = this.$Qmsg.querySelector<HTMLElement>('.qmsg-icon-close')
       if ($closeIcon) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        $closeIcon.addEventListener("click", (_event) => {
-          QmsgContext.close();
-        });
+        $closeIcon.addEventListener('click', _event => {
+          QmsgContext.close()
+        })
       }
     }
     /* 监听动画完成 */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const animationendEvent = (_event: AnimationEvent) => {
-      const animationNameValue = QmsgAnimation.getStyleAnimationNameValue(QmsgContext.$Qmsg);
+      const animationNameValue = QmsgAnimation.getStyleAnimationNameValue(QmsgContext.$Qmsg)
       if (animationNameValue === QmsgAnimation.$state.closing) {
         // 当前触发的是关闭
-        QmsgContext.endTime = Date.now();
-        QmsgContext.destroy();
+        QmsgContext.endTime = Date.now()
+        QmsgContext.destroy()
       }
-      QmsgAnimation.setStyleAnimationName(QmsgContext.$Qmsg);
-    };
+      QmsgAnimation.setStyleAnimationName(QmsgContext.$Qmsg)
+    }
 
     QmsgAnimation.$name.endNameList.forEach(function (animationendName) {
-      QmsgContext.$Qmsg.addEventListener<"animationend">(animationendName as any, animationendEvent);
-    });
+      QmsgContext.$Qmsg.addEventListener<'animationend'>(animationendName as any, animationendEvent)
+    })
 
     /* 自动关闭 */
     if (this.setting.autoClose && this.setting.listenEventToPauseAutoClose) {
       // 鼠标|触摸滑入时，清除自动关闭的定时器
       // 鼠标|触摸滑出时，重新设置定时器
-      this.resetAutoCloseTimer();
+      this.resetAutoCloseTimer()
       /**
        * 鼠标滑入
        *
@@ -282,34 +282,34 @@ export class QmsgMsg {
        */
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const enterEvent = (_event: MouseEvent | TouchEvent) => {
-        this.clearAutoCloseTimer();
-      };
+        this.clearAutoCloseTimer()
+      }
       /** 鼠标滑出，重启定时器，创建新的开始时间和timeId */
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const leaveEvent = (_event: MouseEvent | TouchEvent) => {
         if (this.timeId != null) {
           // 似乎enterEvent函数未正确调用？
-          console.warn("QmsgInst timeId is not null，mouseenter may be not first trigger，timeId：" + this.timeId);
-          return;
+          console.warn('QmsgInst timeId is not null，mouseenter may be not first trigger，timeId：' + this.timeId)
+          return
         }
-        this.startAutoCloseTimer();
-      };
-      let isRemoveMouseEvent = false;
-      this.$Qmsg.addEventListener("mouseenter", enterEvent);
-      this.$Qmsg.addEventListener("mouseleave", leaveEvent);
+        this.startAutoCloseTimer()
+      }
+      let isRemoveMouseEvent = false
+      this.$Qmsg.addEventListener('mouseenter', enterEvent)
+      this.$Qmsg.addEventListener('mouseleave', leaveEvent)
 
-      this.$Qmsg.addEventListener("touchstart", (evt) => {
+      this.$Qmsg.addEventListener('touchstart', evt => {
         // 由于移动端不支持mouseout且会触发mouseenter
         // 那么需要移除该监听
         if (!isRemoveMouseEvent) {
-          isRemoveMouseEvent = true;
-          this.$Qmsg.removeEventListener("mouseenter", enterEvent);
-          this.$Qmsg.removeEventListener("mouseleave", leaveEvent);
+          isRemoveMouseEvent = true
+          this.$Qmsg.removeEventListener('mouseenter', enterEvent)
+          this.$Qmsg.removeEventListener('mouseleave', leaveEvent)
         }
-        enterEvent(evt);
-      });
-      this.$Qmsg.addEventListener("touchend", leaveEvent);
-      this.$Qmsg.addEventListener("touchcancel", leaveEvent);
+        enterEvent(evt)
+      })
+      this.$Qmsg.addEventListener('touchend', leaveEvent)
+      this.$Qmsg.addEventListener('touchcancel', leaveEvent)
     }
   }
   /**
@@ -318,11 +318,11 @@ export class QmsgMsg {
    * timeout必须在规定范围内
    */
   private detectionType() {
-    if (this.setting.timeout != null && typeof this.setting.timeout === "string") {
-      this.setting.timeout = parseInt(this.setting.timeout);
+    if (this.setting.timeout != null && typeof this.setting.timeout === 'string') {
+      this.setting.timeout = parseInt(this.setting.timeout)
     }
     if (isNaN(this.setting.timeout)) {
-      this.setting.timeout = QmsgDefaultConfig.config.timeout;
+      this.setting.timeout = QmsgDefaultConfig.config.timeout
     }
     if (
       !(
@@ -331,20 +331,20 @@ export class QmsgMsg {
         parseInt(this.setting.timeout.toString()) <= Number.MAX_VALUE
       )
     ) {
-      this.setting.timeout = QmsgDefaultConfig.config.timeout;
+      this.setting.timeout = QmsgDefaultConfig.config.timeout
     }
 
-    if (typeof this.setting.zIndex === "function") {
-      this.setting.zIndex = this.setting.zIndex();
+    if (typeof this.setting.zIndex === 'function') {
+      this.setting.zIndex = this.setting.zIndex()
     }
-    if (this.setting.zIndex != null && typeof this.setting.zIndex === "string") {
-      this.setting.zIndex = parseInt(this.setting.zIndex);
+    if (this.setting.zIndex != null && typeof this.setting.zIndex === 'string') {
+      this.setting.zIndex = parseInt(this.setting.zIndex)
     }
     if (isNaN(this.setting.zIndex)) {
       this.setting.zIndex =
-        typeof QmsgDefaultConfig.config.zIndex === "function"
+        typeof QmsgDefaultConfig.config.zIndex === 'function'
           ? QmsgDefaultConfig.config.zIndex()
-          : QmsgDefaultConfig.config.zIndex;
+          : QmsgDefaultConfig.config.zIndex
     }
   }
   /**
@@ -353,116 +353,116 @@ export class QmsgMsg {
    * @param state
    */
   private setState(element: HTMLElement, state: keyof QmsgAnimationState) {
-    if (!state || !QmsgAnimation.$state[state]) return;
-    this.state = state;
-    QmsgAnimation.setStyleAnimationName(element, QmsgAnimation.$state[state]);
+    if (!state || !QmsgAnimation.$state[state]) return
+    this.state = state
+    QmsgAnimation.setStyleAnimationName(element, QmsgAnimation.$state[state])
   }
   /**
    * 设置消息数量统计
    */
   setMsgCount() {
-    const countClassName = QmsgUtils.getNameSpacify("count");
+    const countClassName = QmsgUtils.getNameSpacify('count')
     const wrapperClassName = `div.${QmsgUtils.getNameSpacify(
-      "data-position",
+      'data-position',
       this.setting.position.toLowerCase()
-    )} [class^="qmsg-content-"]`;
-    const $content = this.$Qmsg.querySelector<HTMLElement>(wrapperClassName);
+    )} [class^="qmsg-content-"]`
+    const $content = this.$Qmsg.querySelector<HTMLElement>(wrapperClassName)
     if (!$content) {
-      throw new Error("QmsgInst $content is null");
+      throw new Error('QmsgInst $content is null')
     }
-    let $count = $content.querySelector<HTMLElement>("." + countClassName);
+    let $count = $content.querySelector<HTMLElement>('.' + countClassName)
     if (!$count) {
-      $count = document.createElement("span");
-      $count.classList.add(countClassName);
-      $content.appendChild($count);
+      $count = document.createElement('span')
+      $count.classList.add(countClassName)
+      $content.appendChild($count)
     }
     // 获取重复显示内容的实例数量
-    const repeatNum = this.getRepeatNum();
-    QmsgUtils.setSafeHTML($count, repeatNum.toString());
-    QmsgAnimation.setStyleAnimationName($count);
-    QmsgAnimation.setStyleAnimationName($count, "MessageShake");
-    this.resetAutoCloseTimer();
+    const repeatNum = this.getRepeatNum()
+    QmsgUtils.setSafeHTML($count, repeatNum.toString())
+    QmsgAnimation.setStyleAnimationName($count)
+    QmsgAnimation.setStyleAnimationName($count, 'MessageShake')
+    this.resetAutoCloseTimer()
   }
   /**
    * 清除旧的自动关闭定时器
    */
   clearAutoCloseTimer() {
     /* 重置定时器 */
-    QmsgUtils.clearTimeout(this.timeId);
-    this.timeId = void 0;
-    this.startTime = null;
-    this.endTime = null;
+    QmsgUtils.clearTimeout(this.timeId)
+    this.timeId = void 0
+    this.startTime = null
+    this.endTime = null
   }
   /**
    * 开始自动关闭定时器
    */
   startAutoCloseTimer() {
     if (this.setting.autoClose && this.setting.listenEventToPauseAutoClose) {
-      this.startTime = Date.now();
-      this.endTime = null;
+      this.startTime = Date.now()
+      this.endTime = null
       this.timeId = QmsgUtils.setTimeout(() => {
-        this.close();
-      }, this.setting.timeout);
+        this.close()
+      }, this.setting.timeout)
     }
   }
   /**
    * 重置自动关闭定时器（会自动清理旧的定时器）
    */
   resetAutoCloseTimer() {
-    this.clearAutoCloseTimer();
-    this.startAutoCloseTimer();
+    this.clearAutoCloseTimer()
+    this.startAutoCloseTimer()
   }
   /**
    * 关闭Qmsg（会触发动画）
    */
   close() {
-    this.setState(this.$Qmsg, "closing");
+    this.setState(this.$Qmsg, 'closing')
     if (QmsgAnimation.CAN_ANIMATION) {
       /* 支持动画 */
-      QmsgInstStorage.remove(this.uuid);
+      QmsgInstStorage.remove(this.uuid)
     } else {
       /* 不支持动画 */
-      this.destroy();
+      this.destroy()
     }
-    const onCloseCallBack = this.setting.onClose;
-    if (onCloseCallBack && typeof onCloseCallBack === "function") {
-      onCloseCallBack.call(this);
+    const onCloseCallBack = this.setting.onClose
+    if (onCloseCallBack && typeof onCloseCallBack === 'function') {
+      onCloseCallBack.call(this)
     }
   }
   /**
    * 销毁Qmsg
    */
   destroy() {
-    this.endTime = Date.now();
-    this.$Qmsg.remove();
-    QmsgUtils.clearTimeout(this.timeId);
-    QmsgInstStorage.remove(this.uuid);
-    this.timeId = void 0;
+    this.endTime = Date.now()
+    this.$Qmsg.remove()
+    QmsgUtils.clearTimeout(this.timeId)
+    QmsgInstStorage.remove(this.uuid)
+    this.timeId = void 0
   }
   /**
    * 获取内容元素
    */
   get $content() {
-    const $content = this.$Qmsg.querySelector<HTMLSpanElement>("div[class^=qmsg-content-] > span");
+    const $content = this.$Qmsg.querySelector<HTMLSpanElement>('div[class^=qmsg-content-] > span')
     if (!$content) {
-      throw new Error("QmsgInst $content is null");
+      throw new Error('QmsgInst $content is null')
     }
-    return $content;
+    return $content
   }
   /**
    * 设置内容文本
    */
   setText(text: string) {
-    const $content = this.$content;
-    $content.innerText = text;
-    this.setting.content = text;
+    const $content = this.$content
+    $content.innerText = text
+    this.setting.content = text
   }
   /**
    * 设置内容超文本
    */
   setHTML(text: string) {
-    const $content = this.$content;
-    QmsgUtils.setSafeHTML($content, text);
-    this.setting.content = text;
+    const $content = this.$content
+    QmsgUtils.setSafeHTML($content, text)
+    this.setting.content = text
   }
 }

--- a/src/QmsgInstHandler.ts
+++ b/src/QmsgInstHandler.ts
@@ -1,58 +1,58 @@
-import { QmsgMsg } from "./QmsgInst";
-import { QmsgInstStorage, type QmsgInstStorageInfo } from "./QmsgInstStorage";
-import type { QmsgConfig } from "./QmsgConfig";
-import { QmsgUtils } from "./QmsgUtils";
+import { QmsgMsg } from './QmsgInst'
+import { QmsgInstStorage, type QmsgInstStorageInfo } from './QmsgInstStorage'
+import type { QmsgConfig } from './QmsgConfig'
+import { QmsgUtils } from './QmsgUtils'
 
 /**
  * 通过配置信息 来判断是否为同一条消息,并返回消息实例
  * @param config 配置项
  */
 export function QmsgInstHandler(config: QmsgConfig = {} as QmsgConfig): QmsgMsg {
-  const optionString = JSON.stringify(config);
+  const optionString = JSON.stringify(config)
   /* 寻找已生成的实例是否存在配置相同的 */
-  let findQmsgItemInfo = QmsgInstStorage.insInfoList.find((item) => {
-    return item.config === optionString;
-  });
-  let qmsgInst = findQmsgItemInfo?.instance;
+  let findQmsgItemInfo = QmsgInstStorage.insInfoList.find(item => {
+    return item.config === optionString
+  })
+  let qmsgInst = findQmsgItemInfo?.instance
   if (qmsgInst == null) {
     /* 不存在，创建个新的 */
-    const uuid = QmsgUtils.getUUID();
+    const uuid = QmsgUtils.getUUID()
     const qmsgInstStorageInfo = <QmsgInstStorageInfo>{
       uuid: uuid,
       config: optionString,
-      instance: new QmsgMsg(config, uuid),
-    };
-    QmsgInstStorage.insInfoList.push(qmsgInstStorageInfo);
-    const QmsgListLength = QmsgInstStorage.insInfoList.length;
-    const maxNums = qmsgInstStorageInfo.instance.getSetting().maxNums;
+      instance: new QmsgMsg(config, uuid)
+    }
+    QmsgInstStorage.insInfoList.push(qmsgInstStorageInfo)
+    const QmsgListLength = QmsgInstStorage.insInfoList.length
+    const maxNums = qmsgInstStorageInfo.instance.getSetting().maxNums
     /**
      * 关闭多余的消息
      */
     if (QmsgListLength > maxNums) {
       for (let index = 0; index < QmsgListLength - maxNums; index++) {
-        const item = QmsgInstStorage.insInfoList[index];
-        item && item.instance.getSetting().autoClose && item.instance.close();
+        const item = QmsgInstStorage.insInfoList[index]
+        item && item.instance.getSetting().autoClose && item.instance.close()
       }
     }
-    findQmsgItemInfo = qmsgInstStorageInfo;
-    qmsgInst = qmsgInstStorageInfo.instance;
+    findQmsgItemInfo = qmsgInstStorageInfo
+    qmsgInst = qmsgInstStorageInfo.instance
   } else {
     if (!qmsgInst.getRepeatNum()) {
-      qmsgInst.setRepeatNum(2);
+      qmsgInst.setRepeatNum(2)
     } else {
       if (qmsgInst.getRepeatNum() >= 99) {
         /* pass */
       } else {
-        qmsgInst.setRepeatNumIncreasing();
+        qmsgInst.setRepeatNumIncreasing()
       }
     }
-    qmsgInst.setMsgCount();
+    qmsgInst.setMsgCount()
   }
   if (qmsgInst) {
-    qmsgInst.$Qmsg.setAttribute("data-count", qmsgInst?.getRepeatNum().toString());
+    qmsgInst.$Qmsg.setAttribute('data-count', qmsgInst?.getRepeatNum().toString())
   } else {
-    throw new Error("QmsgInst is null");
+    throw new Error('QmsgInst is null')
   }
 
-  return qmsgInst;
+  return qmsgInst
 }

--- a/src/QmsgInstStorage.ts
+++ b/src/QmsgInstStorage.ts
@@ -1,12 +1,12 @@
-import type { QmsgMsg } from "./QmsgInst";
+import type { QmsgMsg } from './QmsgInst'
 
 /**
  * Qmsg实例存储信息
  */
 export interface QmsgInstStorageInfo {
-  config: string;
-  instance: typeof QmsgMsg.prototype;
-  uuid: string;
+  config: string
+  instance: typeof QmsgMsg.prototype
+  uuid: string
 }
 /**
  * Qmsg实例存储
@@ -24,14 +24,14 @@ export const QmsgInstStorage = {
    * + false 移除失败
    */
   remove(uuid: string) {
-    let flag = false;
+    let flag = false
     for (let index = 0; index < QmsgInstStorage.insInfoList.length; index++) {
       if (QmsgInstStorage.insInfoList[index].uuid === uuid) {
-        QmsgInstStorage.insInfoList.splice(index, 1);
-        flag = true;
-        break;
+        QmsgInstStorage.insInfoList.splice(index, 1)
+        flag = true
+        break
       }
     }
-    return flag;
-  },
-};
+    return flag
+  }
+}

--- a/src/QmsgUtils.ts
+++ b/src/QmsgUtils.ts
@@ -1,6 +1,6 @@
-import { QmsgDefaultConfig } from "./QmsgDefaultConfig";
-import { clearInterval, clearTimeout, setInterval, setTimeout } from "worker-timers";
-import type { QmsgConfig } from "./QmsgConfig";
+import { QmsgDefaultConfig } from './QmsgDefaultConfig'
+import { clearInterval, clearTimeout, setInterval, setTimeout } from 'worker-timers'
+import type { QmsgConfig } from './QmsgConfig'
 
 export const QmsgUtils = {
   /**
@@ -8,59 +8,59 @@ export const QmsgUtils = {
    * @param args
    */
   getNameSpacify(...args: string[]): string {
-    let result = QmsgDefaultConfig.NAMESPACE;
+    let result = QmsgDefaultConfig.NAMESPACE
     for (let index = 0; index < args.length; ++index) {
-      result += "-" + args[index];
+      result += '-' + args[index]
     }
-    return result;
+    return result
   },
   /**
    * 判断字符是否是数字
    * @param text 需要判断的字符串
    */
   isNumber(text: string): boolean {
-    const isNumberPattern = /^\d+$/;
-    return isNumberPattern.test(text);
+    const isNumberPattern = /^\d+$/
+    return isNumberPattern.test(text)
   },
   /**
    * 获取唯一性的UUID
    */
   getUUID(): string {
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (value) {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (value) {
       const randValue = (Math.random() * 16) | 0,
-        newValue = value == "x" ? randValue : (randValue & 0x3) | 0x8;
-      return newValue.toString(16);
-    });
+        newValue = value == 'x' ? randValue : (randValue & 0x3) | 0x8
+      return newValue.toString(16)
+    })
   },
   /**
    * 合并参数为配置信息，用于创建Msg实例
    * @param content 文本内容
    * @param config 配置
    */
-  mergeArgs(content: any = "", config?: object): QmsgConfig {
-    const opts = {} as QmsgConfig;
+  mergeArgs(content: any = '', config?: object): QmsgConfig {
+    const opts = {} as QmsgConfig
     if (arguments.length === 0) {
-      return opts;
+      return opts
     }
     if (config != null) {
       // 传入了2个参数
       // string object
       // object object
-      opts.content = content;
-      if (typeof config === "object" && config != null) {
-        return Object.assign(opts, config);
+      opts.content = content
+      if (typeof config === 'object' && config != null) {
+        return Object.assign(opts, config)
       }
     } else {
       // 传入了1个参数
       // object
       // string
-      if (typeof content === "object" && content != null) {
-        return Object.assign(opts, content);
+      if (typeof content === 'object' && content != null) {
+        return Object.assign(opts, content)
       } else {
-        opts.content = content;
+        opts.content = content
       }
     }
-    return opts;
+    return opts
   },
   /**
    * 转换为动态对象
@@ -68,41 +68,41 @@ export const QmsgUtils = {
    * @param other_obj 获取的其它对象
    */
   toDynamicObject<T1, T2 extends any[]>(obj: T1, ...other_objs: T2): T1 & (T2 extends Array<infer U> ? U : never) {
-    const __obj__ = Object.assign({}, obj ?? {});
-    Object.keys(__obj__).forEach((keyName) => {
+    const __obj__ = Object.assign({}, obj ?? {})
+    Object.keys(__obj__).forEach(keyName => {
       // @ts-ignore
-      let objValue = __obj__[keyName];
+      let objValue = __obj__[keyName]
       Object.defineProperty(__obj__, keyName, {
         get() {
-          const findIndex = other_objs.findIndex((other_obj) => {
+          const findIndex = other_objs.findIndex(other_obj => {
             // 判断其他对象中是否有该属性
             return (
-              typeof other_obj === "object" && other_obj != null && other_obj.hasOwnProperty.call(other_obj, keyName)
-            );
-          });
+              typeof other_obj === 'object' && other_obj != null && other_obj.hasOwnProperty.call(other_obj, keyName)
+            )
+          })
           if (findIndex !== -1) {
             // @ts-ignore
-            const other_objValue = other_objs[findIndex][keyName];
-            return other_objValue;
+            const other_objValue = other_objs[findIndex][keyName]
+            return other_objValue
           } else {
-            return objValue;
+            return objValue
           }
         },
         set(newValue) {
-          objValue = newValue;
-        },
-      });
-    });
-    return __obj__ as any;
+          objValue = newValue
+        }
+      })
+    })
+    return __obj__ as any
   },
   /**
    * 自动使用 Worker 执行 setTimeout
    */
   setTimeout(callback: (...args: any[]) => any, timeout: number) {
     try {
-      return setTimeout(callback, timeout);
+      return setTimeout(callback, timeout)
     } catch {
-      return globalThis.setTimeout(callback, timeout);
+      return globalThis.setTimeout(callback, timeout)
     }
   },
   /**
@@ -111,12 +111,12 @@ export const QmsgUtils = {
   clearTimeout(timeId: number | undefined) {
     try {
       if (timeId != null) {
-        clearTimeout(timeId);
+        clearTimeout(timeId)
       }
     } catch {
       // TODO
     } finally {
-      globalThis.clearTimeout(timeId);
+      globalThis.clearTimeout(timeId)
     }
   },
   /**
@@ -124,9 +124,9 @@ export const QmsgUtils = {
    */
   setInterval(callback: (...args: any[]) => any, timeout: number) {
     try {
-      return setInterval(callback, timeout);
+      return setInterval(callback, timeout)
     } catch {
-      return globalThis.setInterval(callback, timeout);
+      return globalThis.setInterval(callback, timeout)
     }
   },
   /**
@@ -135,12 +135,12 @@ export const QmsgUtils = {
   clearInterval(timeId: number | undefined) {
     try {
       if (timeId != null) {
-        clearInterval(timeId);
+        clearInterval(timeId)
       }
     } catch {
       // TODO
     } finally {
-      globalThis.clearInterval(timeId);
+      globalThis.clearInterval(timeId)
     }
   },
   /**
@@ -149,18 +149,18 @@ export const QmsgUtils = {
   setSafeHTML($el: Element, text: string) {
     // 创建 TrustedHTML 策略（需 CSP 允许）
     try {
-      $el.innerHTML = text;
+      $el.innerHTML = text
     } catch {
       // @ts-ignore
       if (globalThis.trustedTypes) {
         // @ts-ignore
-        const policy = globalThis.trustedTypes.createPolicy("safe-innerHTML", {
-          createHTML: (html: string) => html,
-        });
-        $el.innerHTML = policy.createHTML(text);
+        const policy = globalThis.trustedTypes.createPolicy('safe-innerHTML', {
+          createHTML: (html: string) => html
+        })
+        $el.innerHTML = policy.createHTML(text)
       } else {
-        throw new Error("QmsgUtils trustedTypes is not defined");
+        throw new Error('QmsgUtils trustedTypes is not defined')
       }
     }
-  },
-};
+  }
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,4 +1,5 @@
 @charset "utf-8";
+
 .qmsg.qmsg-wrapper {
   position: fixed;
   top: 16px;
@@ -18,6 +19,7 @@
   pointer-events: none;
   flex-direction: column;
 }
+
 .qmsg.qmsg-data-position-center,
 .qmsg.qmsg-data-position-left,
 .qmsg.qmsg-data-position-right {
@@ -26,6 +28,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
 }
+
 .qmsg.qmsg-data-position-bottom,
 .qmsg.qmsg-data-position-bottomleft,
 .qmsg.qmsg-data-position-bottomright {
@@ -36,21 +39,25 @@
   left: 50%;
   transform: translate(-50%, 0);
 }
+
 .qmsg.qmsg-data-position-bottomleft .qmsg-item,
 .qmsg.qmsg-data-position-left .qmsg-item,
 .qmsg.qmsg-data-position-topleft .qmsg-item {
   text-align: left;
 }
+
 .qmsg.qmsg-data-position-bottom .qmsg-item,
 .qmsg.qmsg-data-position-center .qmsg-item,
 .qmsg.qmsg-data-position-top .qmsg-item {
   text-align: center;
 }
+
 .qmsg.qmsg-data-position-bottomright .qmsg-item,
 .qmsg.qmsg-data-position-right .qmsg-item,
 .qmsg.qmsg-data-position-topright .qmsg-item {
   text-align: right;
 }
+
 .qmsg .qmsg-item {
   position: relative;
   padding: 8px;
@@ -58,6 +65,7 @@
   -webkit-animation-duration: 0.3s;
   animation-duration: 0.3s;
 }
+
 .qmsg .qmsg-item .qmsg-count {
   position: absolute;
   top: -4px;
@@ -74,9 +82,11 @@
   -webkit-animation-duration: 0.3s;
   animation-duration: 0.3s;
 }
+
 .qmsg .qmsg-item:first-child {
   margin-top: -8px;
 }
+
 .qmsg .qmsg-content {
   position: relative;
   display: inline-block;
@@ -89,13 +99,15 @@
   text-align: center;
   pointer-events: all;
 }
+
 .qmsg .qmsg-content [class^="qmsg-content-"] {
   display: flex;
   align-items: center;
 }
+
 .qmsg .qmsg-icon {
   position: relative;
-  top: 1px;
+  top: 0;
   display: inline-block;
   margin-right: 8px;
   color: inherit;
@@ -109,9 +121,11 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
 .qmsg .qmsg-icon svg {
   display: inline-block;
 }
+
 .qmsg .qmsg-content .qmsg-show-more-content {
   display: flex;
   align-items: center;
@@ -120,9 +134,11 @@
   text-overflow: unset;
   padding-right: unset;
 }
+
 .qmsg .qmsg-content-info .qmsg-icon {
   color: #1890ff;
 }
+
 .qmsg .qmsg-icon-close {
   margin: 0;
   margin-left: 8px;
@@ -135,15 +151,18 @@
   cursor: pointer;
   transition: color 0.3s;
 }
-.qmsg .qmsg-icon-close:hover > svg path {
+
+.qmsg .qmsg-icon-close:hover>svg path {
   stroke: #555;
 }
+
 .qmsg .qmsg-icon-close.qmsg-show-more-content {
   position: unset;
   overflow: unset;
   padding-left: 6px;
   margin-right: 0;
 }
+
 .qmsg .animate-turn {
   animation: MessageTurn 1s linear infinite;
   -webkit-animation: MessageTurn 1s linear infinite;

--- a/src/css/keyframes.css
+++ b/src/css/keyframes.css
@@ -2,107 +2,132 @@
   0% {
     -webkit-transform: rotate(0);
   }
+
   25% {
     -webkit-transform: rotate(90deg);
   }
+
   50% {
     -webkit-transform: rotate(180deg);
   }
+
   75% {
     -webkit-transform: rotate(270deg);
   }
+
   100% {
     -webkit-transform: rotate(360deg);
   }
 }
+
 @-webkit-keyframes MessageTurn {
   0% {
     -webkit-transform: rotate(0);
   }
+
   25% {
     -webkit-transform: rotate(90deg);
   }
+
   50% {
     -webkit-transform: rotate(180deg);
   }
+
   75% {
     -webkit-transform: rotate(270deg);
   }
+
   100% {
     -webkit-transform: rotate(360deg);
   }
 }
+
 @-webkit-keyframes MessageMoveOut {
   0% {
     max-height: 150px;
     opacity: 1;
   }
+
   to {
     max-height: 0;
     opacity: 0;
   }
 }
+
 @keyframes MessageMoveOut {
   0% {
     max-height: 150px;
     opacity: 1;
   }
+
   to {
     max-height: 0;
     opacity: 0;
   }
 }
+
 @-webkit-keyframes MessageMoveIn {
   0% {
     opacity: 0;
     transform: translateY(-100%);
     transform-origin: 0 0;
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
     transform-origin: 0 0;
   }
 }
+
 @keyframes MessageMoveIn {
   0% {
     opacity: 0;
     transform: translateY(-100%);
     transform-origin: 0 0;
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
     transform-origin: 0 0;
   }
 }
+
 @-webkit-keyframes MessageShake {
+
   0%,
   100% {
     opacity: 1;
     transform: translateX(0);
   }
+
   25%,
   75% {
     opacity: 0.75;
     transform: translateX(-4px);
   }
+
   50% {
     opacity: 0.25;
     transform: translateX(4px);
   }
 }
+
 @keyframes MessageShake {
+
   0%,
   100% {
     opacity: 1;
     transform: translateX(0);
   }
+
   25%,
   75% {
     opacity: 0.75;
     transform: translateX(-4px);
   }
+
   50% {
     opacity: 0.25;
     transform: translateX(4px);

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,4 +1,4 @@
-declare module "*.css" {
-  const styles: string;
-  export default styles;
+declare module '*.css' {
+  const styles: string
+  export default styles
 }


### PR DESCRIPTION
全项目范围内将 import、字符串、对象等统一为单引号，去除多余分号，调整逗号、括号等格式，提升代码一致性和可读性。未涉及业务逻辑变更。

调整.qmsg .qmsg-icon